### PR TITLE
Update kiosk api url and related functions

### DIFF
--- a/src/kiosks.js
+++ b/src/kiosks.js
@@ -9,16 +9,12 @@ const STATUS_TYPES = {
 
 function getKiosks(cb) {
   fetch(
-    "https://data.cityofnewyork.us/api/views/s4kf-3yrf/rows.json?accessType=DOWNLOAD"
+    "https://data.cityofnewyork.us/resource/s4kf-3yrf.json?$limit=100000"
   )
     .then(res => res.json())
     .then(res => {
-      const { data } = res;
-      const kiosks = data.map(rowToKiosk).sort((a, b) => {
-        const idA = parseInt(a.id.replace("LINK-", ""));
-        const idB = parseInt(b.id.replace("LINK-", ""));
-        return idA - idB;
-      });
+      const data = res;
+      const kiosks = data.map(rowToKiosk)
 
       if (cb) {
         cb(kiosks);
@@ -30,41 +26,10 @@ function getKiosks(cb) {
 }
 
 function rowToKiosk(row) {
-  const [
-    sid,
-    id,
-    position,
-    created_at,
-    created_meta,
-    updated_at,
-    updated_meta,
-    meta,
-    cb_link_id,
-    borough,
-    community_board,
-    council_district,
-    latitude,
-    longitude,
-    link_installation_status,
-    smallest_ppt,
-    street_address,
-    cross_street_1,
-    cross_street_2,
-    ixn_corner,
-    postcode,
-    link_site_id,
-    link_smoke_tested_and_activated,
-    link_installation,
-    neighborhood_tabulation_area,
-    building_identification_number,
-    borough_block_lot,
-    census_tract,
-    location
-  ] = row;
-  const coordinates = [parseFloat(longitude), parseFloat(latitude)];
-  const status = STATUS_TYPES[link_installation_status];
+  const coordinates = [parseFloat(row.longitude), parseFloat(row.latitude)];
+  const status = STATUS_TYPES[row.link_installation_status];
   return {
-    id: cb_link_id,
+    id: row.cb_link_id,
     coordinates,
     status
   };


### PR DESCRIPTION
The existing Link NYC kiosk API endpoint contains a format which the existing code cannot parse and breaks kiosk display on the map.  I suspect the JSON format changed.  Another endpoint from the same source (NYC Open Data) exists which references the same resource and has a better format.  This PR incorporates that endpoint.

The output kiosks.json file this PR produces is tested to work with [network-map](https://github.com/nycmeshnet/network-map).

The kiosk ids no longer follow a simple link-number format, so I removed the sorting.  The sorting is not required by the map.